### PR TITLE
Reduce CPU usage to 0%

### DIFF
--- a/Program/Parsing/Backends/GameInputBackendDevice.cs
+++ b/Program/Parsing/Backends/GameInputBackendDevice.cs
@@ -119,7 +119,7 @@ namespace RB4InstrumentMapper.Parsing
             // We unfortunately can't rely on timestamp to determine state change,
             // as guitar axis changes do not change the timestamp
             // ulong lastTimestamp = 0;
-            while (!threadStop.WaitOne(0))
+            while (!threadStop.WaitOne(1))
             {
                 int hResult = gameInput.GetCurrentReading(GameInputKind.RawDeviceReport, device, out var reading);
                 if (hResult < 0)


### PR DESCRIPTION
Reduces the CPU usage from 8% (on my PC) to 0% by simply waiting a very small amount of time before checking the state of the `threadStop` event.

I know 8% is a small percentage, but it bothered me and the fix was simple 🙂
I did some testing using a PDP Riffmaster and I believe there are no issues.